### PR TITLE
Reduce delay between header and rest of the plot.

### DIFF
--- a/uniplot/uniplot.py
+++ b/uniplot/uniplot.py
@@ -25,10 +25,6 @@ def plot(ys: Any, xs: Optional[Any] = None, **kwargs) -> None:
     series: MultiSeries = MultiSeries(xs=xs, ys=ys)
     options: Options = validate_and_transform_options(series=series, kwargs=kwargs)
 
-    # Print header
-    for line in sections.generate_header(options):
-        print(line)
-
     # Main loop for interactive mode. Will only be executed once when not in
     # interactive mode.
     continue_looping: bool = True
@@ -51,6 +47,10 @@ def plot(ys: Any, xs: Optional[Any] = None, **kwargs) -> None:
                 nr_lines_to_erase += len(options.legend_labels)
             elements.erase_previous_lines(nr_lines_to_erase)
 
+        # Print header
+        for line in sections.generate_header(options):
+            print(line)
+        
         for line in sections.generate_body(
             x_axis_labels, y_axis_labels, pixel_character_matrix, options
         ):


### PR DESCRIPTION
While this may be strictly less efficient,  it makes the header to be plotted roughly at the same time to the rest of the plot, which makes seamless transitions when updating the chart by just re-plotting on top. (otherwise you see the title for a split of a second and then the rest).

When plotting with a loop and a complex enough chart (with title) it should be apparent, you fit the terminal to be exactly on the size of the plot, expecting a clean update, but you get a tittle first and then the rest, breaking the stream-like plotting experience.